### PR TITLE
Restore list styles for Markdown elements

### DIFF
--- a/app/assets/stylesheets/administrate-field-simple_markdown/application.css
+++ b/app/assets/stylesheets/administrate-field-simple_markdown/application.css
@@ -2,3 +2,16 @@
  *= require_self
  *= require simplemde.min
  */
+
+.simple_markdown ul, .simple_markdown ol {
+  margin: 0.5em 0;
+  padding-left: 2em;
+}
+
+.simple_markdown ul {
+  list-style-type: disc;
+}
+
+.simple_markdown ol {
+  list-style-type: decimal;
+}

--- a/app/views/fields/simple_markdown/_form.html.erb
+++ b/app/views/fields/simple_markdown/_form.html.erb
@@ -14,7 +14,7 @@ This partial renders a WYSIWYG text area to help writing Markdown text
 <div class="field-unit__label">
   <%= f.label field.attribute %>
 </div>
-<div class="field-unit__field">
+<div class="field-unit__field simple_markdown">
   <%= f.text_area field.attribute %>
 </div>
 <%= content_for :javascript do %>

--- a/app/views/fields/simple_markdown/_show.html.erb
+++ b/app/views/fields/simple_markdown/_show.html.erb
@@ -9,4 +9,4 @@ This partial renders a Markdown field to HTML
   An instance of Administrate::Field::SimpleMarkdown.
 %>
 
-<%= field.to_html %>
+<div class="simple_markdown"><%= field.to_html %></div>


### PR DESCRIPTION
Thanks for this gem! It solved a problem for me quickly!

One thing: the Administrate default stylesheet removes styling from &lt;li&gt; bullets which makes editing/previewing Markdown a little broken. This gem just adds some CSS styling to the Markdown elements to restore that look.

Let me know if you need any changes!