### PR TITLE
Use snakecase when generating ID

### DIFF
--- a/app/views/fields/simple_markdown/_form.html.erb
+++ b/app/views/fields/simple_markdown/_form.html.erb
@@ -21,7 +21,7 @@ This partial renders a WYSIWYG text area to help writing Markdown text
   <script type="text/javascript">
     $(function() {
       new SimpleMDE({
-        element: document.getElementById('<%= f.object.class.name.downcase %>_<%= field.attribute %>')
+        element: document.getElementById('<%= f.object.class.name.underscore %>_<%= field.attribute %>')
       });
     });
   </script>


### PR DESCRIPTION
This is an issue if the model is more than one word.  E.g. `FooBar` should be `foo_bar`, but `.downcase` makes it `foobar`.