### PR TITLE
Allow passing down options to Redcarpet

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,19 @@ Add to your `FooDashboard`:
 
 ```ruby
 ATTRIBUTE_TYPES = {
-  bar: Field::SimpleMarkdown
+  bar: Field::SimpleMarkdown.with_options({
+    safe_links_only: true,
+    filter_html: true,
+    with_toc_data: true,
+    hard_wrap: true,
+    link_attributes: { rel: 'follow' },
+    autolink: true,
+    tables: true,
+    no_intra_emphasis: true,
+    strikethrough: true,
+    highlight: true,
+    space_after_headers: true
+  })
 }.freeze
 ```
 

--- a/lib/administrate/field/simple_markdown.rb
+++ b/lib/administrate/field/simple_markdown.rb
@@ -28,11 +28,11 @@ module Administrate
 
       def html_renderer
         @html_renderer ||= Redcarpet::Render::HTML.new({
-          safe_links_only: true,
-          filter_html: true,
-          with_toc_data: true,
-          hard_wrap: true,
-          link_attributes: { rel: 'nofollow' }
+          safe_links_only: options.fetch(:safe_links_only, true),
+          filter_html: options.fetch(:filter_html, true),
+          with_toc_data: options.fetch(:with_toc_data, true),
+          hard_wrap: options.fetch(:hard_wrap, true),
+          link_attributes: options.fetch(:link_attributes, { rel: 'nofollow' })
         })
       end
 
@@ -42,12 +42,12 @@ module Administrate
 
       def markdown(renderer)
         @markdown ||= Redcarpet::Markdown.new(renderer, {
-          autolink: true,
-          tables: true,
-          no_intra_emphasis: true,
-          strikethrough: true,
-          highlight: true,
-          space_after_headers: true
+          autolink: options.fetch(:autolink, true),
+          tables: options.fetch(:tables, true),
+          no_intra_emphasis: options.fetch(:no_intra_emphasis, true),
+          strikethrough: options.fetch(:strikethrough, true),
+          highlight: options.fetch(:highlight, true),
+          space_after_headers: options.fetch(:space_after_headers, true)
         })
       end
     end


### PR DESCRIPTION
allow to pass options to the redcarpet renderer:


```ruby
Field::SimpleMarkdown.with_options({
          safe_links_only: true,
          filter_html: true,
          with_toc_data: true,
          hard_wrap: true,
          link_attributes: { rel: 'follow' },
          autolink: true,
          tables: true,
          no_intra_emphasis: true,
          strikethrough: true,
          highlight: true,
          space_after_headers: true
})
```

