### PR TITLE
Hide icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,17 @@ ATTRIBUTE_TYPES = {
     no_intra_emphasis: true,
     strikethrough: true,
     highlight: true,
-    space_after_headers: true
+    space_after_headers: true,
+    simplemde_options: {
+      placeholder: 'Enter your content here',
+      spell_checker: false,
+      hide_icons: %w[image quote heading]
+    }
   })
 }.freeze
 ```
+
+You can customize your editor toolbar config the `simplemde_options` value. For more options check [here](https://github.com/sparksuite/simplemde-markdown-editor)
 
 ## About
 

--- a/app/assets/javascripts/administrate-field-simple_markdown/application.js
+++ b/app/assets/javascripts/administrate-field-simple_markdown/application.js
@@ -12,8 +12,9 @@ function initSimpleMDE(element) {
   if (!element) return;
 
   element.querySelectorAll('[data-simplemde="false"]').forEach(function(el) {
-    var hideIcons = el.getAttribute('data-hide-icons');
-    new SimpleMDE({ element: el, hideIcons: hideIcons });
+    var options = JSON.parse(el.getAttribute('data-simplemde-options'));
+
+    new SimpleMDE(Object.assign({}, { element: el }, options));
     el.setAttribute('data-simplemde', true);
   });
 }

--- a/app/assets/javascripts/administrate-field-simple_markdown/application.js
+++ b/app/assets/javascripts/administrate-field-simple_markdown/application.js
@@ -12,7 +12,8 @@ function initSimpleMDE(element) {
   if (!element) return;
 
   element.querySelectorAll('[data-simplemde="false"]').forEach(function(el) {
-    new SimpleMDE({ element: el });
+    var hideIcons = el.getAttribute('data-hide-icons');
+    new SimpleMDE({ element: el, hideIcons: hideIcons });
     el.setAttribute('data-simplemde', true);
   });
 }

--- a/app/views/fields/simple_markdown/_form.html.erb
+++ b/app/views/fields/simple_markdown/_form.html.erb
@@ -15,5 +15,10 @@ This partial renders a WYSIWYG text area to help writing Markdown text
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field simple_markdown">
-  <%= f.text_area field.attribute, data: { simplemde: false } %>
+  <%= f.text_area field.attribute,
+    data: {
+      simplemde: false,
+      hide_icons: field.hide_icons
+    }
+  %>
 </div>

--- a/app/views/fields/simple_markdown/_form.html.erb
+++ b/app/views/fields/simple_markdown/_form.html.erb
@@ -18,7 +18,7 @@ This partial renders a WYSIWYG text area to help writing Markdown text
   <%= f.text_area field.attribute,
     data: {
       simplemde: false,
-      hide_icons: field.hide_icons
+      simplemde_options: field.simplemde_options
     }
   %>
 </div>

--- a/lib/administrate/field/simple_markdown.rb
+++ b/lib/administrate/field/simple_markdown.rb
@@ -20,6 +20,11 @@ module Administrate
         options.fetch(:hide_icons, []).to_s
       end
 
+      def simplemde_options
+        options.fetch(:simplemde_options, {})
+               .transform_keys { |k| k.to_s.camelize(:lower) }
+      end
+
       def to_html
         markdown(html_renderer).render(data).html_safe
       end

--- a/lib/administrate/field/simple_markdown.rb
+++ b/lib/administrate/field/simple_markdown.rb
@@ -16,6 +16,10 @@ module Administrate
         @data || ''
       end
 
+      def hide_icons
+        options.fetch(:hide_icons, []).to_s
+      end
+
       def to_html
         markdown(html_renderer).render(data).html_safe
       end

--- a/lib/administrate/field/simple_markdown.rb
+++ b/lib/administrate/field/simple_markdown.rb
@@ -5,7 +5,6 @@ require 'administrate/field/text'
 require 'administrate/engine'
 require 'redcarpet'
 require 'redcarpet/render_strip'
-require 'byebug'
 
 module Administrate
   module Field

--- a/lib/administrate/field/simple_markdown.rb
+++ b/lib/administrate/field/simple_markdown.rb
@@ -1,8 +1,11 @@
+# frozen_string_literal: true
+
 require 'rails'
 require 'administrate/field/text'
 require 'administrate/engine'
 require 'redcarpet'
 require 'redcarpet/render_strip'
+require 'byebug'
 
 module Administrate
   module Field
@@ -14,10 +17,6 @@ module Administrate
 
       def data
         @data || ''
-      end
-
-      def hide_icons
-        options.fetch(:hide_icons, []).to_s
       end
 
       def simplemde_options
@@ -36,13 +35,13 @@ module Administrate
       private
 
       def html_renderer
-        @html_renderer ||= Redcarpet::Render::HTML.new({
+        @html_renderer ||= Redcarpet::Render::HTML.new(
           safe_links_only: options.fetch(:safe_links_only, true),
           filter_html: options.fetch(:filter_html, true),
           with_toc_data: options.fetch(:with_toc_data, true),
           hard_wrap: options.fetch(:hard_wrap, true),
-          link_attributes: options.fetch(:link_attributes, { rel: 'nofollow' })
-        })
+          link_attributes: options.fetch(:link_attributes, rel: 'nofollow')
+        )
       end
 
       def plaintext_renderer
@@ -50,14 +49,13 @@ module Administrate
       end
 
       def markdown(renderer)
-        @markdown ||= Redcarpet::Markdown.new(renderer, {
-          autolink: options.fetch(:autolink, true),
-          tables: options.fetch(:tables, true),
-          no_intra_emphasis: options.fetch(:no_intra_emphasis, true),
-          strikethrough: options.fetch(:strikethrough, true),
-          highlight: options.fetch(:highlight, true),
-          space_after_headers: options.fetch(:space_after_headers, true)
-        })
+        @markdown ||= Redcarpet::Markdown.new(renderer,
+                                              autolink: options.fetch(:autolink, true),
+                                              tables: options.fetch(:tables, true),
+                                              no_intra_emphasis: options.fetch(:no_intra_emphasis, true),
+                                              strikethrough: options.fetch(:strikethrough, true),
+                                              highlight: options.fetch(:highlight, true),
+                                              space_after_headers: options.fetch(:space_after_headers, true))
       end
     end
   end

--- a/spec/lib/administrate/field/simple_markdown_spec.rb
+++ b/spec/lib/administrate/field/simple_markdown_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Administrate::Field::SimpleMarkdown do
@@ -30,21 +32,29 @@ describe Administrate::Field::SimpleMarkdown do
     end
   end
 
-  describe '#hide_icons' do
-    let(:output) { subject.hide_icons }
+  describe '#simplemde_options' do
+    let(:output) { subject.simplemde_options }
     let(:data) { text }
 
     context 'with nil' do
-      it 'returns an empty array' do
-        expect(output).to eq "[]"
+      it 'returns an empty hash' do
+        expect(output).to eq({})
       end
     end
 
-    context 'with a valid option' do
-      let(:options) { { hide_icons: ['foo', 'bar'] } }
+    context 'with a valid options' do
+      let(:options) do
+        { simplemde_options:
+          {
+            foo_bar: 'foobar',
+            bar_foo: %w[bar foo]
+          } }
+      end
 
-      it 'returns the data' do
-        expect(output).to eq '["foo", "bar"]'
+      it 'returns the options into a hash' do
+        expect(output).to eq(
+          'barFoo' => %w[bar foo], 'fooBar' => 'foobar'
+        )
       end
     end
   end

--- a/spec/lib/administrate/field/simple_markdown_spec.rb
+++ b/spec/lib/administrate/field/simple_markdown_spec.rb
@@ -1,11 +1,14 @@
 require 'spec_helper'
 
 describe Administrate::Field::SimpleMarkdown do
-  subject { Administrate::Field::SimpleMarkdown.new(:simple_markdown, data, :show) }
+  subject { described_class.new(:simple_markdown, data, :show) }
 
   let(:md) { '**foo** is the new _bar_' }
   let(:text) { 'foo is the new bar' }
   let(:html) { '<p><strong>foo</strong> is the new <em>bar</em></p>' }
+  let(:options) { {} }
+
+  before { allow(subject).to receive(:options).and_return(options) }
 
   describe '#data' do
     let(:output) { subject.data }
@@ -23,6 +26,25 @@ describe Administrate::Field::SimpleMarkdown do
 
       it 'returns the data' do
         expect(output).to eq text
+      end
+    end
+  end
+
+  describe '#hide_icons' do
+    let(:output) { subject.hide_icons }
+    let(:data) { text }
+
+    context 'with nil' do
+      it 'returns an empty array' do
+        expect(output).to eq "[]"
+      end
+    end
+
+    context 'with a valid option' do
+      let(:options) { { hide_icons: ['foo', 'bar'] } }
+
+      it 'returns the data' do
+        expect(output).to eq '["foo", "bar"]'
       end
     end
   end


### PR DESCRIPTION
Replace `hide_icons` option with `simplemde_options` in order to pass more config settings to simplemde.

Related to https://github.com/zooppa/administrate-field-simple_markdown/issues/14