### PR TITLE
Support nonce for Content Security Policy

### DIFF
--- a/app/views/fields/simple_markdown/_form.html.erb
+++ b/app/views/fields/simple_markdown/_form.html.erb
@@ -22,12 +22,12 @@ This partial renders a WYSIWYG text area to help writing Markdown text
   %>
 </div>
 <%= content_for :javascript do %>
-  <script type="text/javascript">
+  <%= javascript_tag nonce: true do %>
     $(function() {
       var el = document.getElementById('<%= field.html_id %>')
       var options = JSON.parse(el.getAttribute('data-easymde-options'));
 
       new EasyMDE(Object.assign({}, { element: el }, options));
     });
-  </script>
+  <%- end %>
 <% end %>


### PR DESCRIPTION
If an app uses Content Security Policy, the javascript in this file won't run without this nonce setting. Zero downside if you don't use CSP, works the same.